### PR TITLE
DOC: Add repo description and link scipy.datasets docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,8 @@ This repo serves the data files for the
 the [scipy.datasets](https://scipy.github.io/devdocs/reference/datasets.html)
 submodule.
 
-The usage, retrieval and caching of data files is explained in
-[Usage of Datasets](https://scipy.github.io/devdocs/reference/datasets.html#usage-of-datasets).
+You may want to read the
+[Usage of Datasets](https://scipy.github.io/devdocs/reference/datasets.html#usage-of-datasets)
+and
+[How dataset retrieval and storage works?](https://scipy.github.io/devdocs/reference/datasets.html#how-dataset-retrieval-and-storage-works)
+to uncover the working of scipy.datasets module with pooch.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # dataset-ascent
+
+This repo serves the data files for the
+[scipy.dataset.ascent](https://scipy.github.io/devdocs/reference/dataset/ascent.html)
+(visit for details on dataset) method in 
+the [scipy.datasets](https://scipy.github.io/devdocs/reference/datasets.html)
+submodule.
+
+The usage, retrieval and caching of data files is explained in
+[Usage of Datasets](https://scipy.github.io/devdocs/reference/datasets.html#usage-of-datasets).


### PR DESCRIPTION
Add a basic description to the dataset-ascent repo as requested in https://github.com/scipy/scipy/pull/15607#issuecomment-1183617500.